### PR TITLE
購入キャンセル機能(管理者側)の実装

### DIFF
--- a/cmd/api/handler-api.go
+++ b/cmd/api/handler-api.go
@@ -549,6 +549,13 @@ func (app *application) RefundCharge(w http.ResponseWriter, r *http.Request) {
 		Currency: chargeToRefund.Currency,
 	}
 
+	config := config2.LoadConfig()
+	err = app.DB.UpdateOrderStatus(chargeToRefund.ID, config.Status["Refunded"])
+	if err != nil {
+		app.badRequest(w, r, errors.New("charge was refunded"))
+		return
+	}
+
 	err = card.Refund(chargeToRefund.PaymentIntent, chargeToRefund.Amount)
 	if err != nil {
 		app.badRequest(w, r, err)

--- a/cmd/api/handler-api.go
+++ b/cmd/api/handler-api.go
@@ -574,3 +574,45 @@ func (app *application) RefundCharge(w http.ResponseWriter, r *http.Request) {
 
 	app.writeJSON(w, http.StatusOK, resp)
 }
+
+func (app *application) CancelSubscription(w http.ResponseWriter, r *http.Request) {
+	var subToCancel struct {
+		ID            int    `json:"id"`
+		PaymentIntent string `json:"pi"`
+		Currency      string `json:"currency"`
+	}
+
+	err := app.readJSON(w, r, &subToCancel)
+	if err != nil {
+		app.badRequest(w, r, err)
+		return
+	}
+
+	card := cards.Card{
+		Secret:   app.config.stripe.secret,
+		Key:      app.config.stripe.key,
+		Currency: subToCancel.Currency,
+	}
+
+	err = card.CancelSubscription(subToCancel.PaymentIntent)
+	if err != nil {
+		app.badRequest(w, r, err)
+		return
+	}
+
+	config := config2.LoadConfig()
+	err = app.DB.UpdateOrderStatus(subToCancel.ID, config.Status["Cancelled"])
+	if err != nil {
+		app.badRequest(w, r, errors.New("charge was cancelled"))
+		return
+	}
+
+	var resp struct {
+		Error   bool   `json:"error"`
+		Message string `json:"message"`
+	}
+	resp.Error = false
+	resp.Message = "subscription cancelled"
+
+	app.writeJSON(w, http.StatusOK, resp)
+}

--- a/cmd/api/handler-api.go
+++ b/cmd/api/handler-api.go
@@ -528,3 +528,39 @@ func (app *application) AllSubscriptions(w http.ResponseWriter, r *http.Request)
 
 	app.writeJSON(w, http.StatusOK, allSales)
 }
+
+func (app *application) RefundCharge(w http.ResponseWriter, r *http.Request) {
+	var chargeToRefund struct {
+		ID            int    `json:"id"`
+		PaymentIntent string `json:"pi"`
+		Amount        int    `json:"amount"`
+		Currency      string `json:"currency"`
+	}
+
+	err := app.readJSON(w, r, &chargeToRefund)
+	if err != nil {
+		app.badRequest(w, r, err)
+		return
+	}
+
+	card := cards.Card{
+		Secret:   app.config.stripe.secret,
+		Key:      app.config.stripe.key,
+		Currency: chargeToRefund.Currency,
+	}
+
+	err = card.Refund(chargeToRefund.PaymentIntent, chargeToRefund.Amount)
+	if err != nil {
+		app.badRequest(w, r, err)
+		return
+	}
+
+	var resp struct {
+		Error   bool   `json:"error"`
+		Message string `json:"message"`
+	}
+	resp.Error = false
+	resp.Message = "charge refund"
+
+	app.writeJSON(w, http.StatusOK, resp)
+}

--- a/cmd/api/handler-api.go
+++ b/cmd/api/handler-api.go
@@ -137,6 +137,7 @@ func (app *application) CreateCustomerAndSubscribeToPlan(w http.ResponseWriter, 
 		okey = false
 		txnMsg = msg
 	}
+
 	if okey {
 		subscription, err = card.SubscribeToPlan(stripeCustomer, data.Plan, data.Email, data.LastFour, "")
 		if err != nil {
@@ -165,6 +166,8 @@ func (app *application) CreateCustomerAndSubscribeToPlan(w http.ResponseWriter, 
 			ExpiryMonth:         data.ExpiryMonth,
 			ExpiryYear:          data.ExpiryYear,
 			TransactionStatusID: config.Status["Refunded"],
+			PaymentIntent:       subscription.ID,
+			PaymentMethod:       data.PaymentMethod,
 		}
 		txnID, err := app.SaveTransaction(txn)
 		if err != nil {

--- a/cmd/api/routes-api.go
+++ b/cmd/api/routes-api.go
@@ -33,6 +33,7 @@ func (app *application) routes() http.Handler {
 		mux.Post("/all-subscriptions", app.AllSubscriptions)
 
 		mux.Post("/refund", app.RefundCharge)
+		mux.Post("/cancel", app.CancelSubscription)
 	})
 
 	return mux

--- a/cmd/api/routes-api.go
+++ b/cmd/api/routes-api.go
@@ -31,6 +31,9 @@ func (app *application) routes() http.Handler {
 		mux.Post("/all-sales", app.AllSales)
 		mux.Post("/get-sale/{id}", app.GetSale)
 		mux.Post("/all-subscriptions", app.AllSubscriptions)
+
+		mux.Post("/refund", app.RefundCharge)
 	})
+
 	return mux
 }

--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -364,6 +364,10 @@ func (app *application) ShowSale(w http.ResponseWriter, r *http.Request) {
 	stringMap := make(map[string]string)
 	stringMap["title"] = "Sale"
 	stringMap["cancel"] = "/admin/all-sales"
+	stringMap["refund-url"] = "/api/admin/refund"
+	stringMap["refund-btn"] = "Refund Order"
+	stringMap["refund-badge"] = "Refunded"
+	stringMap["refund-msg"] = "Charge refunded"
 
 	if err := app.renderTemplate(w, r, "sale", &templateData{
 		StringMap: stringMap,

--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -386,6 +386,10 @@ func (app *application) ShowSubscription(w http.ResponseWriter, r *http.Request)
 	stringMap := make(map[string]string)
 	stringMap["title"] = "Subscription"
 	stringMap["cancel"] = "/admin/all-subscriptions"
+	stringMap["refund-url"] = "/api/admin/cancel"
+	stringMap["refund-btn"] = "Cancel Subscription"
+	stringMap["refund-badge"] = "Cancelled"
+	stringMap["refund-msg"] = "Subscription cancelled"
 
 	if err := app.renderTemplate(w, r, "sale", &templateData{
 		StringMap: stringMap,

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -17,7 +17,7 @@ func (app *application) routes() http.Handler {
 		mux.Get("/all-sales", app.AllSales)
 		mux.Get("/sales/{id}", app.ShowSale)
 		mux.Get("/all-subscriptions", app.AllSubscriptions)
-		mux.Get("/sales/{id}", app.ShowSubscription)
+		mux.Get("/subscriptions/{id}", app.ShowSubscription)
 	})
 
 	mux.Get("/widget/{id}", app.ChargeOnce)

--- a/cmd/web/templates/all-sales.page.gohtml
+++ b/cmd/web/templates/all-sales.page.gohtml
@@ -15,6 +15,7 @@
                 <th>customer</th>
                 <th>product</th>
                 <th>amount</th>
+                <th>status</th>
             </tr>
         </thead>
         <tbody></tbody>
@@ -57,6 +58,13 @@
                             newCell = newRow.insertCell();
                             item = document.createTextNode(currency);
                             newCell.appendChild(item);
+
+                            newCell = newRow.insertCell();
+                            if (i.status_id == 1) {
+                                newCell.innerHTML = `<span class="badge bg-success">charged</span>`
+                            } else {
+                                newCell.innerHTML = `<span class="badge bg-danger">refunded</span>`
+                            }
                         })
                     } else {
                         let newRow = tbody.insertRow();

--- a/cmd/web/templates/all-subscriptions.page.gohtml
+++ b/cmd/web/templates/all-subscriptions.page.gohtml
@@ -15,6 +15,7 @@
             <th>customer</th>
             <th>product</th>
             <th>amount</th>
+            <th>status</th>
         </tr>
         </thead>
         <tbody></tbody>
@@ -43,7 +44,7 @@
                             let newRow = tbody.insertRow();
                             let newCell = newRow.insertCell();
 
-                            newCell.innerHTML = `<a href="/admin/sales/${i.id}">Order ${i.id}</a>`
+                            newCell.innerHTML = `<a href="/admin/subscriptions/${i.id}">Order ${i.id}</a>`
 
                             newCell = newRow.insertCell();
                             let item = document.createTextNode(i.customer.last_name + ", " + i.customer.first_name);
@@ -57,6 +58,13 @@
                             newCell = newRow.insertCell();
                             item = document.createTextNode(currency + "/month");
                             newCell.appendChild(item);
+
+                            newCell = newRow.insertCell();
+                            if (i.status_id == 1) {
+                                newCell.innerHTML = `<span class="badge bg-success">charged</span>`
+                            } else {
+                                newCell.innerHTML = `<span class="badge bg-danger">Cancelled</span>`
+                            }
                         })
                     } else {
                         let newRow = tbody.insertRow();

--- a/cmd/web/templates/sale.page.gohtml
+++ b/cmd/web/templates/sale.page.gohtml
@@ -15,15 +15,20 @@
         <strong>total sale:</strong><span id="amount"></span><br>
     </div>
     <a class="btn btn-info" href='{{index .StringMap "cancel"}}'>Back</a>
-    <a class="btn btn-warning" href="#!">Refund Order</a>
+    <a class="btn btn-warning" id="refund-btn" href="#!">Refund Order</a>
+
+    <input type="hidden" id="pi" value="">
+    <input type="hidden" id="charge-amount" value="">
+    <input type="hidden" id="currency" value="">
 {{end}}
 
 
 {{define "js"}}
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script>
+        let token = localStorage.getItem("token");
+        let id = window.location.pathname.split("/").pop();
         document.addEventListener("DOMContentLoaded", function () {
-            let token = localStorage.getItem("token");
-            let id = window.location.pathname.split("/").pop();
             const requestOptions = {
                 method: 'post',
                 headers: {
@@ -42,17 +47,55 @@
                         document.getElementById("product").innerText = data.widget.name;
                         document.getElementById("quantity").innerText = data.quantity;
                         document.getElementById("amount").innerText = formatCurrency(data.transaction.amount);
-
+                        document.getElementById("pi").value = data.transaction.payment_intent;
+                        document.getElementById("charge-amount").value = data.transaction.amount;
+                        document.getElementById("currency").value = data.transaction.currency;
                     }
                 })
+        })
 
-            function formatCurrency(amount) {
-                let c = parseFloat(amount);
-                return c.toLocaleString("ja-JP", {
-                    style: "currency",
-                    currency: "JPY",
-                });
-            }
+        function formatCurrency(amount) {
+            let c = parseFloat(amount);
+            return c.toLocaleString("ja-JP", {
+                style: "currency",
+                currency: "JPY",
+            });
+        }
+
+        document.getElementById("refund-btn").addEventListener("click", function() {
+            Swal.fire({
+                title: 'Are you sure?',
+                text: "You won't be able to undo this!",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#3085d6',
+                cancelButtonColor: '#d33',
+                confirmButtonText: 'refund'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    let payload = {
+                        id: parseInt(id, 10),
+                        pi: document.getElementById("pi").value,
+                        amount: parseInt(document.getElementById("charge-amount").value, 10),
+                        currency: document.getElementById("currency").value,
+                    }
+
+                    const requestOptions = {
+                        method: 'post',
+                        headers: {
+                            'Accept': 'application/json',
+                            'Content-Type': 'application/json',
+                            'Authorization': 'Bearer ' + token,
+                        },
+                        body: JSON.stringify(payload),
+                    }
+
+                    fetch("{{.API}}/api/admin/refund", requestOptions)
+                        .then(response => response.json())
+                        .then(function (data) {
+                        })
+                }
+            })
         })
     </script>
 {{end}}

--- a/cmd/web/templates/sale.page.gohtml
+++ b/cmd/web/templates/sale.page.gohtml
@@ -7,7 +7,7 @@
 {{define "content"}}
     <h2 class="mt-5">{{index .StringMap "title"}}</h2>
     <span class="badge bg-success d-none" id="charged">charged</span>
-    <span class="badge bg-danger d-none" id="refunded">refunded</span>
+    <span class="badge bg-danger d-none" id="refunded">{{index .StringMap "refund-badge"}}</span>
     <hr>
     <div class="alert alert-danger text-center d-none" id="messages"></div>
     <div>
@@ -18,7 +18,7 @@
         <strong>total sale:</strong><span id="amount"></span><br>
     </div>
     <a class="btn btn-info" href='{{index .StringMap "cancel"}}'>Back</a>
-    <a class="btn btn-warning d-none" id="refund-btn" href="#!">Refund Order</a>
+    <a class="btn btn-warning d-none" id="refund-btn" href="#!">{{index .StringMap "refund-btn"}}</a>
 
     <input type="hidden" id="pi" value="">
     <input type="hidden" id="charge-amount" value="">
@@ -95,7 +95,7 @@
                 showCancelButton: true,
                 confirmButtonColor: '#3085d6',
                 cancelButtonColor: '#d33',
-                confirmButtonText: 'refund'
+                confirmButtonText: '{{index .StringMap "refund-btn"}}'
             }).then((result) => {
                 if (result.isConfirmed) {
                     let payload = {
@@ -115,11 +115,11 @@
                         body: JSON.stringify(payload),
                     }
 
-                    fetch("{{.API}}/api/admin/refund", requestOptions)
+                    fetch("{{.API}}{{index .StringMap "refund-url"}}", requestOptions)
                         .then(response => response.json())
                         .then(function (data) {
                             if (!data.error) {
-                                showSuccess("charge refunded");
+                                showSuccess("{{index .StringMap "refund-msg"}}");
                                 document.getElementById("refund-btn").classList.add("d-none");
                                 document.getElementById("refunded").classList.remove("d-none");
                                 document.getElementById("charged").classList.add("d-none");

--- a/cmd/web/templates/sale.page.gohtml
+++ b/cmd/web/templates/sale.page.gohtml
@@ -6,7 +6,10 @@
 
 {{define "content"}}
     <h2 class="mt-5">{{index .StringMap "title"}}</h2>
+    <span class="badge bg-success d-none" id="charged">charged</span>
+    <span class="badge bg-danger d-none" id="refunded">refunded</span>
     <hr>
+    <div class="alert alert-danger text-center d-none" id="messages"></div>
     <div>
         <strong>order No:</strong><span id="order-no"></span><br>
         <strong>customer name:</strong><span id="customer"></span><br>
@@ -15,7 +18,7 @@
         <strong>total sale:</strong><span id="amount"></span><br>
     </div>
     <a class="btn btn-info" href='{{index .StringMap "cancel"}}'>Back</a>
-    <a class="btn btn-warning" id="refund-btn" href="#!">Refund Order</a>
+    <a class="btn btn-warning d-none" id="refund-btn" href="#!">Refund Order</a>
 
     <input type="hidden" id="pi" value="">
     <input type="hidden" id="charge-amount" value="">
@@ -28,6 +31,22 @@
     <script>
         let token = localStorage.getItem("token");
         let id = window.location.pathname.split("/").pop();
+        let messages = document.getElementById("messages");
+
+        function showSuccess(msg) {
+            messages.classList.add("alert-success");
+            messages.classList.remove("alert-danger");
+            messages.classList.remove("d-none");
+            messages.innerText = msg;
+        }
+
+        function showError(msg) {
+            messages.classList.add("alert-danger");
+            messages.classList.remove("alert-success");
+            messages.classList.remove("d-none");
+            messages.innerText = msg;
+        }
+
         document.addEventListener("DOMContentLoaded", function () {
             const requestOptions = {
                 method: 'post',
@@ -50,6 +69,12 @@
                         document.getElementById("pi").value = data.transaction.payment_intent;
                         document.getElementById("charge-amount").value = data.transaction.amount;
                         document.getElementById("currency").value = data.transaction.currency;
+                        if (data.status_id == 1) {
+                            document.getElementById("refund-btn").classList.remove("d-none");
+                            document.getElementById("charged").classList.remove("d-none");
+                        } else {
+                            document.getElementById("refunded").classList.remove("d-none");
+                        }
                     }
                 })
         })
@@ -93,6 +118,15 @@
                     fetch("{{.API}}/api/admin/refund", requestOptions)
                         .then(response => response.json())
                         .then(function (data) {
+                            if (!data.error) {
+                                showSuccess("charge refunded");
+                                document.getElementById("refund-btn").classList.add("d-none");
+                                document.getElementById("refunded").classList.remove("d-none");
+                                document.getElementById("charged").classList.add("d-none");
+
+                            } else {
+                                showError(data.message);
+                            }
                         })
                 }
             })

--- a/internal/cards/cards.go
+++ b/internal/cards/cards.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stripe/stripe-go/v75/customer"
 	"github.com/stripe/stripe-go/v75/paymentintent"
 	"github.com/stripe/stripe-go/v75/paymentmethod"
+	"github.com/stripe/stripe-go/v75/refund"
 	"github.com/stripe/stripe-go/v75/subscription"
 )
 
@@ -127,4 +128,21 @@ func cardErrorMessage(code stripe.ErrorCode) string {
 		msg = "your card was declined"
 	}
 	return msg
+}
+
+func (c *Card) Refund(pi string, amount int) error {
+	stripe.Key = c.Secret
+	amountToRefund := int64(amount)
+
+	refundParams := &stripe.RefundParams{
+		Amount:        &amountToRefund,
+		PaymentIntent: &pi,
+	}
+
+	_, err := refund.New(refundParams)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/cards/cards.go
+++ b/internal/cards/cards.go
@@ -146,3 +146,18 @@ func (c *Card) Refund(pi string, amount int) error {
 
 	return nil
 }
+
+func (c *Card) CancelSubscription(subID string) error {
+	stripe.Key = c.Secret
+
+	params := &stripe.SubscriptionParams{
+		CancelAtPeriodEnd: stripe.Bool(true),
+	}
+
+	_, err := subscription.Update(subID, params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -340,3 +340,17 @@ func (m *DBModel) GetOrderByID(orderID int) (Order, error) {
 	}
 	return o, nil
 }
+
+func (m *DBModel) UpdateOrderStatus(id, statusID int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	stmt := "update orders set status_id = ? where id = ?"
+
+	_, err := m.DB.ExecContext(ctx, stmt, statusID, id)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## 概要

管理者側で商品、サブスクの購入キャンセルが行える

## 変更点

## 影響範囲

## テスト

- [ ] 管理者ログインで以下のページにアクセスし、キャンセルが行えること
    - [ ] 商品購入履歴詳細(/admin/sales/{id})
    - [ ] サブスク購入履歴詳細(/admin/sales/{id})
- [ ] キャンセル後のステータスが変更されること
    - [ ] 商品:refund
    - [ ] サブスク: cancel
- [ ] 一度キャンセルした商品・サブスクは再度キャンセルができないこと

## 関連Issue

closes: https://github.com/Natsumag/EC_APP_for_golang/issues/13