### PR TITLE
バリデーションの強化の実装

### DIFF
--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -95,3 +95,16 @@ func (app *application) passwordMatches(hash, password string) (bool, error) {
 
 	return true, nil
 }
+
+func (app *application) failedValidation(w http.ResponseWriter, r *http.Request, errors map[string]string) {
+	var payload struct {
+		Error   bool              `json:"error"`
+		Message string            `json:"message"`
+		Errors  map[string]string `json:"errors"`
+	}
+
+	payload.Error = true
+	payload.Message = "failed validation"
+	payload.Errors = errors
+	app.writeJSON(w, http.StatusUnprocessableEntity, payload)
+}

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -3,10 +3,9 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"golang.org/x/crypto/bcrypt"
 	"io"
 	"net/http"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 func (app *application) writeJSON(w http.ResponseWriter, status int, data interface{}, headers ...http.Header) error {
@@ -96,11 +95,11 @@ func (app *application) passwordMatches(hash, password string) (bool, error) {
 	return true, nil
 }
 
-func (app *application) failedValidation(w http.ResponseWriter, r *http.Request, errors map[string]string) {
+func (app *application) failedValidation(w http.ResponseWriter, r *http.Request, errors map[string][]string) {
 	var payload struct {
-		Error   bool              `json:"error"`
-		Message string            `json:"message"`
-		Errors  map[string]string `json:"errors"`
+		Error   bool                `json:"error"`
+		Message string              `json:"message"`
+		Errors  map[string][]string `json:"errors"`
 	}
 
 	payload.Error = true

--- a/cmd/web/templates/bronze-plan.page.gohtml
+++ b/cmd/web/templates/bronze-plan.page.gohtml
@@ -15,12 +15,14 @@
         <p>{{$widget.Description}}</p>
         <hr>
         <div class="mb-3">
-            <label for="first-name" class="form-label">First Name</label>
-            <input type="text" class="form-control" id="first-name" name="first_name" required autocomplete="first-name-new">
+            <label for="first_name" class="form-label">First Name</label>
+            <input type="text" class="form-control" id="first_name" name="first_name" required autocomplete="first_name-new">
+            <div class="invalid-feedback" id="first_name-help"></div>
         </div>
         <div class="mb-3">
-            <label for="last-name" class="form-label">Last Name</label>
-            <input type="text" class="form-control" id="last-name" name="last_name" required autocomplete="last-name-new">
+            <label for="last_name" class="form-label">Last Name</label>
+            <input type="text" class="form-control" id="last_name" name="last_name" required autocomplete="last_name-new">
+            <div class="invalid-feedback" id="last_name-help"></div>
         </div>
         <div class="mb-3">
             <label for="cardholder-name" class="form-label">Name on Card</label>
@@ -29,6 +31,7 @@
         <div class="mb-3">
             <label for="email" class="form-label">Email</label>
             <input type="email" class="form-control" id="email" name="email" required autocomplete="email-new">
+            <div class="invalid-feedback" id="email-help"></div>
         </div>
 
         {{/* stripe */}}
@@ -122,8 +125,8 @@
                     card_bland: result.paymentMethod.card_bland,
                     exp_month: result.paymentMethod.card.exp_month,
                     exp_year: result.paymentMethod.card.exp_year,
-                    first_name: document.getElementById("first-name").value,
-                    last_name: document.getElementById("last-name").value,
+                    first_name: document.getElementById("first_name").value,
+                    last_name: document.getElementById("last_name").value,
                     amount: document.getElementById("amount").value,
                 }
 
@@ -139,14 +142,24 @@
                 fetch("{{.API}}/api/create-customer-and-subscribe-to-plan", requestOptions)
                     .then(response => response.json())
                     .then(function (data) {
-                        processing.classList.add("d-none");
-                        showCardSuccess();
-                        sessionStorage.first_name = document.getElementById("first-name").value
-                        sessionStorage.last_name = document.getElementById("last-name").value
-                        sessionStorage.amount = "{{formatCurrency $widget.Price}}";
-                        sessionStorage.last_four = result.paymentMethod.card.last4;
+                        if (data.error === false) {
+                            processing.classList.add("d-none");
+                            showCardSuccess();
+                            sessionStorage.first_name = document.getElementById("first_name").value
+                            sessionStorage.last_name = document.getElementById("last_name").value
+                            sessionStorage.amount = "{{formatCurrency $widget.Price}}";
+                            sessionStorage.last_four = result.paymentMethod.card.last4;
 
-                        location.href = "/receipt/bronze";
+                            location.href = "/receipt/bronze";
+                        }
+                        document.getElementById("charge_form").classList.remove("was-validated");
+                        Object.entries(data.errors).forEach((i) => {
+                            const [key, value] = i;
+                            document.getElementById(key).classList.add("is-invalid");
+                            document.getElementById(key + "-help").classList.add("invalid-feedback");
+                            document.getElementById(key + "-help").innerText = value;
+                        })
+                        showPayButtons();
                     });
             }
         }

--- a/cmd/web/templates/forgot-password.page.gohtml
+++ b/cmd/web/templates/forgot-password.page.gohtml
@@ -20,7 +20,6 @@
             </form>
         </div>
     </div>
-
 {{end}}
 
 {{define "js"}}
@@ -40,7 +39,6 @@
             messages.classList.remove("d-none");
             messages.innerText = msg;
         }
-
 
         function val() {
             let form = document.getElementById("forgot_form");

--- a/cmd/web/templates/forgot-password.page.gohtml
+++ b/cmd/web/templates/forgot-password.page.gohtml
@@ -14,6 +14,7 @@
                 <div class="mb-3">
                     <label for="email" class="form-label">Email</label>
                     <input type="email" class="form-control" id="email" name="email" required autocomplete="email-new">
+                    <div class="invalid-feedback" id="email-help"></div>
                 </div>
                 <hr>
                 <a href="javascript:void(0)" class="btn btn-primary" onclick="val()">Send Password Reset</a>
@@ -66,11 +67,19 @@
             fetch("{{.API}}/api/forgot-password", requestOptions)
                 .then(response => response.json())
                 .then(data => {
-                    if (data.error) {
-                        showError(data.message);
-                        return;
+                    console.log(data.error);
+                    if (data.error === false) {
+                        showSuccess();
+                        location.href = "/login";
                     }
-                    showSuccess();
+                    document.getElementById("forgot_form").classList.remove("was-validated");
+                    Object.entries(data.errors).forEach((i) => {
+                        const [key, value] = i;
+                        document.getElementById(key).classList.add("is-invalid");
+                        document.getElementById(key + "-help").classList.add("invalid-feedback");
+                        document.getElementById(key + "-help").innerText = value;
+                    })
+                    showError(data.message);
                 })
         }
     </script>

--- a/cmd/web/templates/home.page.gohtml
+++ b/cmd/web/templates/home.page.gohtml
@@ -7,5 +7,4 @@
 {{define "content"}}
     <h2 class="mt-5">Widgets</h2>
     <hr>
-
 {{end}}

--- a/cmd/web/templates/login.page.gohtml
+++ b/cmd/web/templates/login.page.gohtml
@@ -5,19 +5,20 @@
 {{end}}
 
 {{define "content"}}
-
     <div class="alert alert-danger text-center d-none" id="login-messages"></div>
-    <form action="/login" method="post" name="login_form" id="login_form" class="d-block needs-validation charge-form" autocomplete="off" novalidate="">
+    <form action="/login" method="post" name="login_form" id="login_form" class="d-block needs-validation login_form" autocomplete="off" novalidate="">
         <h2 class="mt-2 text-center mb-3">Login</h2>
         <hr>
 
         <div class="mb-3">
             <label for="email" class="form-label">Email</label>
             <input type="email" class="form-control" id="email" name="email" required autocomplete="email-new">
+            <div class="invalid-feedback" id="email-help"></div>
         </div>
         <div class="mb-3">
             <label for="password" class="form-label">Password</label>
             <input type="password" class="form-control" id="password" name="password" required autocomplete="password-new">
+            <div class="invalid-feedback" id="password-help"></div>
         </div>
         <hr>
         <a href="javascript:void(0)" class="btn btn-primary" onclick="val()">Login</a>
@@ -70,7 +71,16 @@
             fetch("{{.API}}/api/authenticate", requestOptions)
                 .then(response => response.json())
                 .then(data => {
+                    console.log("data.error", data.error);
                     if (data.error) {
+                        console.log("afdsfsdasfdfds");
+                        document.getElementById("login_form").classList.remove("was-validated");
+                        Object.entries(data.errors).forEach((i) => {
+                            const [key, value] = i;
+                            document.getElementById(key).classList.add("is-invalid");
+                            document.getElementById(key + "-help").classList.add("invalid-feedback");
+                            document.getElementById(key + "-help").innerText = value;
+                        })
                         showError(data.message);
                         return;
                     }
@@ -78,8 +88,9 @@
                     localStorage.setItem('token', data.authentication_token.token);
                     localStorage.setItem('token_expiry', data.authentication_token.expiry);
                     showSuccess();
+
                     document.getElementById("login_form").submit();
-                })
+                });
         }
     </script>
 {{end}}

--- a/cmd/web/templates/login.page.gohtml
+++ b/cmd/web/templates/login.page.gohtml
@@ -43,7 +43,6 @@
             loginMessages.innerText = msg;
         }
 
-
         function val() {
             let form = document.getElementById("login_form");
             if (form.checkValidity() === false) {

--- a/cmd/web/templates/one-user.page.gohtml
+++ b/cmd/web/templates/one-user.page.gohtml
@@ -6,26 +6,31 @@
 {{define "content"}}
     <h2 class="mt-5">admin user</h2>
     <hr>
-    <form method="post" action="" name="user_form" class="needs-validation" id="user_form" autocomplete="off" novalidate="">
+    <form method="post" action="" name="user_form" class="d-block needs-validation" id="user_form" autocomplete="off" novalidate="">
         <div class="mb-3">
             <label for="first_name" class="form-label">first name</label>
             <input type="text" class="form-control" id="first_name" name="first_name" autocomplete="first_name-new" required="">
+            <div class="invalid-feedback" id="first_name-help"></div>
         </div>
         <div class="mb-3">
             <label for="last_name" class="form-label">last name</label>
             <input type="text" class="form-control" id="last_name" name="last_name" autocomplete="last_name-new" required="">
+            <div class="invalid-feedback" id="last_name-help"></div>
         </div>
         <div class="mb-3">
             <label for="email" class="form-label">email</label>
             <input type="email" class="form-control" id="email" name="email" autocomplete="email-new" required="">
+            <div class="invalid-feedback" id="email-help"></div>
         </div>
         <div class="mb-3">
             <label for="password" class="form-label">password</label>
             <input type="password" class="form-control" id="password" name="password" autocomplete="password-new">
+            <div class="invalid-feedback" id="password-help"></div>
         </div>
         <div class="mb-3">
             <label for="verify_password" class="form-label">verify password</label>
             <input type="password" class="form-control" id="verify_password" name="verify_password" autocomplete="verify_password-new">
+            <div class="invalid-feedback" id="verify_password-help"></div>
         </div>
         <hr>
         <div class="float-start">
@@ -94,19 +99,18 @@
                     fetch("{{.API}}/api/admin/all-users/delete/" + id, requestOptions)
                         .then(response => response.json())
                         .then(data => {
-                            if (data.error) {
-                                Swal.fire("Error: " + data.message);
-                                return
-                            }
-                            let jsonData = {
-                                action: "deleteUser",
-                                user_id: parseInt(id, 10),
-                            }
-                            if (socket) {
-                                socket.send(JSON.stringify(jsonData));
+                            if (data.error === false) {
+                                let jsonData = {
+                                    action: "deleteUser",
+                                    user_id: parseInt(id, 10),
+                                }
+                                if (socket) {
+                                    socket.send(JSON.stringify(jsonData));
+                                }
+                                location.href = "/admin/all-users";
                             }
 
-                            location.href = "/admin/all-users";
+                            Swal.fire("Error: " + data.message);
                         })
                 }
             })
@@ -133,6 +137,7 @@
                 last_name: document.getElementById("last_name").value,
                 email: document.getElementById("email").value,
                 password: document.getElementById("password").value,
+                verify_password: document.getElementById("verify_password").value,
             }
 
             const requestOptions = {
@@ -148,11 +153,19 @@
             fetch("{{.API}}/api/admin/all-users/edit/" + id, requestOptions)
                 .then(response => response.json())
                 .then(data => {
-                    if (data.error) {
-                        Swal.fire("Error: " + data.message);
-                        return
+                    if (data.error === false) {
+                        location.href = "/admin/all-users";
                     }
-                    location.href = "/admin/all-users";
+
+                    document.getElementById("user_form").classList.remove("was-validated");
+                    Object.entries(data.errors).forEach((i) => {
+                        const [key, value] = i;
+                        document.getElementById(key).classList.add("is-invalid");
+                        document.getElementById(key + "-help").classList.add("invalid-feedback");
+                        document.getElementById(key + "-help").innerText = value;
+                    })
+
+                    Swal.fire("Error: " + data.message);
                 })
         }
     </script>

--- a/cmd/web/templates/reset-password.page.gohtml
+++ b/cmd/web/templates/reset-password.page.gohtml
@@ -46,7 +46,6 @@
             messages.innerText = msg;
         }
 
-
         function val() {
             let form = document.getElementById("reset_form");
             if (form.checkValidity() === false) {

--- a/cmd/web/templates/reset-password.page.gohtml
+++ b/cmd/web/templates/reset-password.page.gohtml
@@ -14,11 +14,13 @@
                 <div class="mb-3">
                     <label for="password" class="form-label">Password</label>
                     <input type="password" class="form-control" id="password" name="password" required autocomplete="password-new">
+                    <div class="invalid-feedback" id="password-help"></div>
                 </div>
 
                 <div class="mb-3">
                     <label for="verify-password" class="form-label">Verify Password</label>
                     <input type="password" class="form-control" id="verify-password" name="verify-password" required autocomplete="verify-password-new">
+                    <div class="invalid-feedback" id="password-help"></div>
                 </div>
                 <hr>
                 <a href="javascript:void(0)" class="btn btn-primary" onclick="val()">Reset Password</a>
@@ -62,8 +64,9 @@
             }
 
             let payload = {
-                password: document.getElementById("password").value,
                 email: "{{index .Data "email"}}",
+                password: document.getElementById("password").value,
+                verify_password: document.getElementById("verify-password").value,
             }
 
             const requestOptions = {
@@ -78,15 +81,21 @@
             fetch("{{.API}}/api/reset-password", requestOptions)
                 .then(response => response.json())
                 .then(data => {
-                    if (data.error) {
-                        showError(data.message);
-                        return;
+                    if (data.error === false) {
+                        showSuccess();
+                        setTimeout(function () {
+                            location.href = "/login";
+                        }, 2000);
                     }
 
-                    showSuccess();
-                    setTimeout(function () {
-                        location.href = "/login";
-                    }, 2000);
+                    document.getElementById("reset_form").classList.remove("was-validated");
+                    Object.entries(data.errors).forEach((i) => {
+                        const [key, value] = i;
+                        document.getElementById(key).classList.add("is-invalid");
+                        document.getElementById(key + "-help").classList.add("invalid-feedback");
+                        document.getElementById(key + "-help").innerText = value;
+                    })
+                    showError(data.message);
                 })
         }
     </script>

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -81,13 +81,14 @@ type Transaction struct {
 }
 
 type User struct {
-	ID        int       `json:"id"`
-	FirstName string    `json:"first_name"`
-	LastName  string    `json:"last_name"`
-	Email     string    `json:"email"`
-	Password  string    `json:"password"`
-	CreatedAt time.Time `json:"-"`
-	UpdatedAt time.Time `json:"-"`
+	ID             int       `json:"id"`
+	FirstName      string    `json:"first_name"`
+	LastName       string    `json:"last_name"`
+	Email          string    `json:"email"`
+	Password       string    `json:"password"`
+	VerifyPassword string    `json:"verify_password"`
+	CreatedAt      time.Time `json:"-"`
+	UpdatedAt      time.Time `json:"-"`
 }
 
 type Customer struct {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ExtractDomain(email string) (string, error) {
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid email format")
+	}
+	return parts[1], nil
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,0 +1,25 @@
+package validator
+
+type Validator struct {
+	Errors map[string]string
+}
+
+func New() *Validator {
+	return &Validator{Errors: make(map[string]string)}
+}
+
+func (v *Validator) Valid() bool {
+	return len(v.Errors) == 0
+}
+
+func (v *Validator) AddError(key, message string) {
+	if _, exists := v.Errors[key]; !exists {
+		v.Errors[key] = message
+	}
+}
+
+func (v *Validator) Check(ok bool, key, message string) {
+	if !ok {
+		v.AddError(key, message)
+	}
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,11 +1,11 @@
 package validator
 
 type Validator struct {
-	Errors map[string]string
+	Errors map[string][]string
 }
 
 func New() *Validator {
-	return &Validator{Errors: make(map[string]string)}
+	return &Validator{Errors: make(map[string][]string)}
 }
 
 func (v *Validator) Valid() bool {
@@ -14,7 +14,7 @@ func (v *Validator) Valid() bool {
 
 func (v *Validator) AddError(key, message string) {
 	if _, exists := v.Errors[key]; !exists {
-		v.Errors[key] = message
+		v.Errors[key] = append(v.Errors[key], message)
 	}
 }
 


### PR DESCRIPTION
## 概要

API側のバリデーションを強化

## 変更点

## 影響範囲

## テスト

- [ ] 以下の画面でバリデーションが正常に動作すること(バリデーションの要件は、以下の「### 今回追加したバリデーション」に記載)
    - [ ] ユーザー登録(/admin/all-users/{id})
    - [ ] サブスク購入(/plans/bronze)
    - [ ] パスワードリセットメール送信(/forgot-password)
    - [ ] ログイン(/login)
    - [ ] パスワードリセット(/reset-password)
- [ ] それぞれの画面で、バリデーションを通過した場合、正常処理が行えること

### 今回追加したバリデーション

- first_name, last_name
    - 2文字以上255文字以下
    - 入れられる文字はa-z, A-Zのみ
- email
    - 8文字以上320文字以下
    - 不正な値はNG(正規表現: `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$` )
    - 存在しないドメインはNG
- password
    - 2文字以上255文字以下
    - verify_passwordと一致している

## 関連Issue

closes: https://github.com/Natsumag/EC_APP_for_golang/issues/21